### PR TITLE
fix: support rinhers without social in RinherCard

### DIFF
--- a/src/components/rinher-card.tsx
+++ b/src/components/rinher-card.tsx
@@ -77,7 +77,7 @@ export function RinherCard({ rinher }: RinherCardProps) {
           <a href={sourceCodeRepo} target="_blank"><code>Source code</code></a>
 
           <div className="flex gap-4">
-            {social.map(s => <a key={s} href={s}><SmartIcon src={s} /></a>)}
+            {social?.map(s => <a key={s} href={s}><SmartIcon src={s} /></a>)}
           </div>
         </div>
       </li>

--- a/src/types/rinher.ts
+++ b/src/types/rinher.ts
@@ -1,6 +1,6 @@
 export type Rinher = {
   'name': string;
-  'social': string[];
+  'social'?: string[];
   'source-code-repo': string;
   'langs'?: string[];
   'storages'?: string[];


### PR DESCRIPTION
Alguns participantes não colocaram o campo 'social' no info.json, o que causava falha no build do site.  
Esta correção torna o campo 'social' opcional e trata sua ausência no componente `RinherCard`.