### PR TITLE
fix: map que tá quebrando o site em prod

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,46 +3,46 @@ name: Update Rinhers.json Daily
 on:
   schedule:
     # Runs every day at midnight UTC
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch: # Allows manual triggering
 
 jobs:
   run-script:
     runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.GH_PAT }}
-      
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
-        
-    - name: Cache Bun dependencies
-      uses: actions/cache@v4.2.3
-      with:
-        path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-bun-
-          
-    - name: Install dependencies
-      run: bun install
-      
-    - name: Run script
-      run: bun run script/index.ts
-      env:
-        GITHUB_AUTH_TOKEN: ${{ secrets.GH_PAT }}
 
-    - name: Commit and push changes
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add .
-        git diff --staged --quiet || git commit -m "chore: update rinhers.json - $(date '+%Y-%m-%d %H:%M:%S')"
-        git push
-      env:
-        GITHUB_AUTH_TOKEN: ${{ secrets.GH_PAT }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run script
+        run: bun gen
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git diff --staged --quiet || git commit -m "chore: update rinhers.json - $(date '+%Y-%m-%d %H:%M:%S')"
+          git push
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GH_PAT }}

--- a/rinhers.json
+++ b/rinhers.json
@@ -1727,6 +1727,7 @@
     },
     {
       "name": "rinhabackend-spring-java",
+      "social": [],
       "source-code-repo": "https://github.com/matheuslf/rinha-backend-2025",
       "langs": [
         "java"


### PR DESCRIPTION
# motivação

no momento que abri o site hoje vi que nada tava carregando por conta de um `.map` que tá acontencedo em uma variável `undefined` (`undefined.map(...)`).

<img width="1259" height="620" alt="image" src="https://github.com/user-attachments/assets/40bc9b6d-7a71-4822-a03d-9289d7a497c1" />

# solução

só um repositório que tinha o json faltando o array de social, mesmo que seja vazio, só adicionei no `rinhers.json` o array vazio pra não quebrar em runtime.

# possível iteração futura

javascript não é uma linguagem nem um pouco confiável no tópico de segurança de tipos e evicção de _undefined behavior_, logo, se faz necessário a utilização de runtime validators pra poder garantir que o formato dos dados sejam minimamente confiáveis.

recomendaria que colocássemos algo tipo `zod`, `typia`, `valibot` ou o que seja pra validar que os dados estejam corretos no script, e fazer isso quebrar o CI.

a ideia é que ao rodar `bun gen` todas as rotinas serão executadas, o único passo extra é que antes de escrever no arquivo `rinhers.json` seria executado uma função de validação de dados.